### PR TITLE
Edited Elasticsearch and Kibana Yaml files

### DIFF
--- a/dev/elastic/elasticsearch.yaml
+++ b/dev/elastic/elasticsearch.yaml
@@ -3,13 +3,25 @@ kind: Elasticsearch
 metadata:
   name: elastic
 spec:
-  version: 8.13.1
+  version: 8.13.2
   nodeSets:
   - name: master
     count: 3
     config:
       node.roles: ["master", "data", "ingest"]
       node.store.allow_mmap: false
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          env:
+          - name: ES_JAVA_OPTS
+            value: "-Xms3g -Xmx3g"
+          resources:
+            requests:
+              memory: 6Gi
+            limits:
+              memory: 6Gi
 ---
 apiVersion: v1
 kind: Service

--- a/dev/elastic/kibana.yaml
+++ b/dev/elastic/kibana.yaml
@@ -3,7 +3,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.13.1
+  version: 8.13.2
   count: 1
   elasticsearchRef:
     name: elastic


### PR DESCRIPTION
Jvm heap size, ram limit and latest version editing have been made for Elasticsearch. For Kibana, only the version upgrade has been made.


Closes #38 